### PR TITLE
fix: mobile UI issues — modal z-index, editor width, touch targets (#…

### DIFF
--- a/src/app/(app)/notes/[id]/page.tsx
+++ b/src/app/(app)/notes/[id]/page.tsx
@@ -225,7 +225,7 @@ export default function NotePage({
       </div>
 
       <div className="flex flex-1 min-h-0">
-        <div className={`p-4 overflow-y-auto ${isMobile ? "transition-[height] duration-200 ease-out" : "flex-1"}`} style={{ backgroundColor: "var(--surface-content)", ...(isMobile ? { height: `calc(100dvh - 6rem - ${getSheetHeight(synthesisSheetState)})` } : {}) }}>
+        <div className={`w-full p-4 overflow-y-auto ${isMobile ? "transition-[height] duration-200 ease-out" : "flex-1"}`} style={{ backgroundColor: "var(--surface-content)", ...(isMobile ? { height: `calc(100dvh - 6rem - ${getSheetHeight(synthesisSheetState)})` } : {}) }}>
           <NoteEditor
             noteId={id}
             content={note.content}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -68,7 +68,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   return (
     <div ref={containerRef} className="flex flex-col h-screen">
-      <header className="h-12 border-b border-border flex items-center px-4 gap-2 shrink-0 bg-background">
+      <header className="h-12 border-b border-border flex items-center px-2 md:px-4 gap-2 shrink-0 bg-background">
         <Button
           variant="ghost"
           size="icon-sm"

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -67,10 +67,11 @@ export function ThemeSwitcher() {
       <Button
         variant="ghost"
         size="icon-sm"
+        className="size-11 md:size-8"
         onClick={() => setOpen(!open)}
         aria-label="Change theme"
       >
-        <Palette className="size-4" />
+        <Palette className="size-5 md:size-4" />
       </Button>
 
       {open && (

--- a/src/components/UserBadge.tsx
+++ b/src/components/UserBadge.tsx
@@ -9,9 +9,9 @@ export function UserBadge() {
     <div className="flex items-center gap-3">
       <Link
         href="/settings"
-        className="inline-flex items-center justify-center size-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+        className="inline-flex items-center justify-center size-11 md:size-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
       >
-        <Settings className="size-4" />
+        <Settings className="size-5 md:size-4" />
       </Link>
       <Show when="signed-in">
         <UserButton />

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -25,8 +25,8 @@ export function ConfirmDialog({
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-sm rounded-lg border border-border bg-popover p-6 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 w-full max-w-sm rounded-lg border border-border bg-popover p-6 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
           <Dialog.Title className="text-lg font-semibold">
             {title}
           </Dialog.Title>


### PR DESCRIPTION
…18-#21)

- Add z-50 to ConfirmDialog overlay/content so modal renders above sidebar
- Add w-full to mobile editor container so empty notes fill width
- Reduce mobile header padding (px-2) to move hamburger closer to edge
- Increase settings gear and theme switcher to 44px touch targets on mobile

Closes #18, closes #19, closes #20, closes #21

## Summary

<!-- Brief description of what this PR does and why. -->

## Spec Reference

<!-- Link to the spec in specs/ that this PR implements. -->

## Checklist

- [ ] Spec referenced above and implementation matches it
- [ ] Decisions made during implementation are logged as ADRs in `ADR/`
- [ ] Tests considered (added, updated, or explicitly not needed with rationale)
- [ ] Documentation updated (ARCHITECTURE.md, PROMPTS.md, or other docs as needed)
- [ ] No hardcoded model names, API keys, or secrets
- [ ] Conventional commit messages used
